### PR TITLE
Correct Summary Group active to actual

### DIFF
--- a/input/fsh/Profile-SummaryGroup.fsh
+++ b/input/fsh/Profile-SummaryGroup.fsh
@@ -3,5 +3,4 @@ Parent: Group
 Id: study-summary-group
 Title: "NCPI Summary Group"
 Description: "Represent a group of research subjects, either the entire study's population or a subgroup such as an individual consent group"
-* active 1..1
-* active = true
+* actual = true


### PR DESCRIPTION
Incorrectly set SummaryGroup's active to required and true, when that should have been actual. This has been fixed. 