### PR TITLE
Requiring URL property for AD 

### DIFF
--- a/input/fsh/Example-Dataset-DD.fsh
+++ b/input/fsh/Example-Dataset-DD.fsh
@@ -43,6 +43,7 @@ InstanceOf: StudyDdTable
 Title: "Data-Dictionary Table"
 Description: "Example Data Table definition"
 * status = #active
+* url = $ExampleStudyTableCS
 * code.coding = $ExampleStudyDatasetCS#demographics "Demographic data"
 * topic.coding = $umls#C0035168 "Research"
 * observationResultRequirement[0] = Reference(example-study-dd-variable-1-1)

--- a/input/fsh/Profile-StudyDdTable.fsh
+++ b/input/fsh/Profile-StudyDdTable.fsh
@@ -5,4 +5,5 @@ Title: "NCPI Study DD Data Table"
 Description: "Aggregates Variable Details associated with a single dataset table that are represented in FHIR"
 * ^version = "0.1.0"
 * ^status = #draft
+* url 1..1
 

--- a/input/pagecontent/StructureDefinition-study-dd-table-intro.md
+++ b/input/pagecontent/StructureDefinition-study-dd-table-intro.md
@@ -1,1 +1,3 @@
 The study table represents a single table from the dataset and aggregates each of the variables that are represented in FHIR. 
+
+The _url_ property is required and must contain the _system_ associated with the table's codes. 

--- a/input/pagecontent/data-dictionary.md
+++ b/input/pagecontent/data-dictionary.md
@@ -1,6 +1,6 @@
 ### The Data Dictionary
 
-The data-dictionary acts as the key to the dataset itself. Traditionally, this file is delivered alongside with flat files that are passed along to researchers and contain column names, descriptions along with other details to help the individuals doing analysis to understand how they are expected to use the data. FHIR provides descriptive resource types that can reasonably be used for the purposes of describing the variables that are found within a given dataset.
+The data-dictionary acts as the key to the dataset itself. Traditionally, this file is delivered as flat files that are passed along to researchers as part of the dataset delivery itself and contain column names, descriptions along with other details to help the individuals doing analysis to understand how they are expected to use the data. FHIR provides descriptive resource types that can reasonably be used for the purposes of describing the variables that are found within a given dataset.
 
 <img width="100%" src="ncpi-dd.png" alt="DD Resource Overview" />
 


### PR DESCRIPTION
This is required in order to support automatic association with the corresponding code-system.